### PR TITLE
Bumped the meck dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {deps, [
     {bear, "0.1.3p1", {git, "git://github.com/basho/bear.git", {tag, "0.1.3p1"}}},
-    {meck, "0.8.1", {git, "git://github.com/basho/meck.git", {tag, "0.8.1"}}}
+    {meck, "0.8.*", {git, "git://github.com/basho/meck.git", {tag, "0.8.1p1"}}}
 ]}.
 
 {erl_opts, [debug_info]}.


### PR DESCRIPTION
basho/erlang_protobuffs requires meck 0.8.1p1.

This prevents the usage of riak_core and riak-erlang-client in the same project, as riak_core depends on folsom and riak-erlang-client on erlang_protobuffs.